### PR TITLE
Implement RTK API to simplify API calls over axios

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/parser": "^5.62.0",
+        "cors": "^2.8.5",
         "express": "^4.21.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/cookie-parser": "^1.4.8",
+        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.8",
         "@types/mysql": "^2.15.26",
@@ -371,6 +373,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/express": {
@@ -1084,6 +1096,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2488,6 +2513,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@typescript-eslint/parser": "^5.62.0",
+    "cors": "^2.8.5",
     "express": "^4.21.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.8",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.8",
     "@types/mysql": "^2.15.26",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,8 +11,17 @@ import plantRoutes from './routes/plants';
 import cookieParser from 'cookie-parser';
 import swaggerUi from 'swagger-ui-express';
 import { specs } from './config/swagger';
+import cors from 'cors';
 
 const app = express();
+
+// Cors to allow requests from the frontend
+app.use(
+    cors({
+        origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+        credentials: true,
+    })
+)
 
 // Middleware to parse Cookies
 app.use(cookieParser());

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^2.5.1",
         "@typescript-eslint/parser": "^8.23.0",
         "bootstrap": "^5.3.3",
+        "lodash": "^4.17.21",
         "mdb-react-ui-kit": "^9.0.0",
         "prettier": "^3.4.2",
         "prettier-eslint": "^16.3.0",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@types/node": "^22.13.4",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@types/react-router-bootstrap": "^0.26.6",
@@ -34,7 +36,6 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
-        "redux-toolkit": "^1.1.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5"
@@ -1745,6 +1746,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -2726,16 +2737,6 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "license": "ISC"
     },
-    "node_modules/flux-standard-action": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
-      "integrity": "sha512-CBd2tVQN1xvBz7i2ZMPP7XvMbZQCSl/Pz4a00JRQyipYlKNUwsHJctZW+dveCAxFySMvXlVJNevyfMOgT8Byvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.isplainobject": "^3.2.0"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -3136,55 +3137,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
-      "dev": true,
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
-    },
-    "node_modules/lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-      "integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._basefor": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.keysin": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.keysin": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-      "integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4292,35 +4248,6 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/redux-toolkit": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/redux-toolkit/-/redux-toolkit-1.1.2.tgz",
-      "integrity": "sha512-ZDs6LqSvGLy5kcFfl3yHB/xzpPlXodryCex4ICJUJ2s1SiE/zUsbT/y4YU5IDJafNh4cmTr/J518nTJ+V4rIOQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.2.0",
-        "flux-standard-action": "^0.6.0",
-        "invariant": "^2.1.1",
-        "lodash": "^3.10.1"
-      }
-    },
-    "node_modules/redux-toolkit/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/redux-toolkit/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -4675,6 +4602,13 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4834,12 +4768,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/vue-eslint-parser/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -4878,6 +4806,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@reduxjs/toolkit": "^2.5.1",
     "@typescript-eslint/parser": "^8.23.0",
     "bootstrap": "^5.3.3",
+    "lodash": "^4.17.21",
     "mdb-react-ui-kit": "^9.0.0",
     "prettier": "^3.4.2",
     "prettier-eslint": "^16.3.0",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/node": "^22.13.4",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/react-router-bootstrap": "^0.26.6",
@@ -37,7 +39,6 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
-    "redux-toolkit": "^1.1.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5"

--- a/frontend/src/components/common/AppNavbar.tsx
+++ b/frontend/src/components/common/AppNavbar.tsx
@@ -1,17 +1,18 @@
 import { Link } from "react-router-dom";
 import { Navbar, Nav, Container } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
-import axios from "axios";
-import { logout } from "../../redux/user/slice";
+import { logout, UserState } from "../../redux/user/slice";
+import { api } from "../../redux/api";
 
 const AppNavbar = () => {
   const dispatch = useDispatch();
-  const user = useSelector((state) => state.user);
+  const user = useSelector((state: { user: UserState }) => state.user);
+  const [logoutUser] = api.useLogoutMutation();
 
   const handleLogout = async () => {
     // Call the logout REST api endpoint and clear the user state
-    await axios.post("/api/auth/logout");
-    dispatch(logout(user));
+    await logoutUser(user);
+    dispatch(logout());
   };
 
   return (

--- a/frontend/src/redux/api.ts
+++ b/frontend/src/redux/api.ts
@@ -9,6 +9,7 @@ export const api = createApi({
         baseUrl: baseUrl,
         credentials: 'include',
     }),
+    tagTypes: ['Plants'],
     endpoints: (builder) => ({
         login: builder.mutation({
             query: (credentials) => ({
@@ -35,6 +36,7 @@ export const api = createApi({
         }),
         getPlants: builder.query({
             query: () => '/plants',
+            providesTags: ['Plants'],
         }),
         getPlantById: builder.query({
             query: (id) => `/plants/${id}`,
@@ -45,6 +47,7 @@ export const api = createApi({
                 method: 'POST',
                 body: newPlant,
             }),
+            invalidatesTags: ['Plants'],
         }),
         updatePlant: builder.mutation({
             query: ({ id, ...updatedPlant }) => ({
@@ -52,12 +55,14 @@ export const api = createApi({
                 method: 'PUT',
                 body: updatedPlant,
             }),
+            invalidatesTags: ['Plants'],
         }),
         deletePlant: builder.mutation({
             query: (id) => ({
                 url: `/plants/${id}`,
                 method: 'DELETE',
             }),
+            invalidatesTags: ['Plants'],
         }),
     }),
 });

--- a/frontend/src/redux/api.ts
+++ b/frontend/src/redux/api.ts
@@ -1,0 +1,63 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { logout } from './user/slice';
+
+const baseUrl = 'http://localhost:8800/api';
+
+export const api = createApi({
+    reducerPath: 'api',
+    baseQuery: fetchBaseQuery({
+        baseUrl: baseUrl,
+        credentials: 'include',
+    }),
+    endpoints: (builder) => ({
+        login: builder.mutation({
+            query: (credentials) => ({
+                url: '/auth/login',
+                method: 'POST',
+                body: credentials,
+            }),
+        }),
+        register: builder.mutation({
+            query: (credentials) => ({
+                url: '/auth/register',
+                method: 'POST',
+                body: credentials,
+            }),
+        }),
+        logout: builder.mutation({
+            query: () => ({
+                url: '/auth/logout',
+                method: 'POST',
+            }),
+            onQueryStarted: (_, { dispatch }) => {
+                dispatch(logout());
+            },
+        }),
+        getPlants: builder.query({
+            query: () => '/plants',
+        }),
+        getPlantById: builder.query({
+            query: (id) => `/plants/${id}`,
+        }),
+        addPlant: builder.mutation({
+            query: (newPlant) => ({
+                url: '/plants',
+                method: 'POST',
+                body: newPlant,
+            }),
+        }),
+        updatePlant: builder.mutation({
+            query: ({ id, ...updatedPlant }) => ({
+                url: `/plants/${id}`,
+                method: 'PUT',
+                body: updatedPlant,
+            }),
+        }),
+        deletePlant: builder.mutation({
+            query: (id) => ({
+                url: `/plants/${id}`,
+                method: 'DELETE',
+            }),
+        }),
+    }),
+});

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,22 +1,33 @@
 import { configureStore } from "@reduxjs/toolkit";
-import userReducer, { initialState } from "./redux/user/slice";
+import userReducer, { initialState as userInitialState } from "./redux/user/slice";
+import { api } from "./redux/api";
 
-const persistedState = localStorage.getItem('userState')
-    ? JSON.parse(localStorage.getItem('userState')!)
-    : undefined;
+// Load user state from local storage
+const persistedState = localStorage.getItem("userState")
+  ? JSON.parse(localStorage.getItem("userState")!)
+  : undefined;
 
-const store = configureStore({
+export const store = configureStore({
   reducer: {
     user: userReducer,
+    // Merge the RTK Query reducer
+    [api.reducerPath]: api.reducer,
   },
-  preloadedState: { user: persistedState || initialState },
+  // Rehydrate just the user state (or whichever slices you want)
+  preloadedState: {
+    user: persistedState || userInitialState,
+  },
+  middleware: (getDefaultMiddleware) =>
+    // Add the RTK Query middleware so queries and mutations work
+    getDefaultMiddleware().concat(api.middleware),
 });
 
+// Persist the user slice to local storage on every state change
 store.subscribe(() => {
-  localStorage.setItem('userState', JSON.stringify(store.getState()));
+  const { user } = store.getState();
+  localStorage.setItem("userState", JSON.stringify(user));
 });
 
+// Export types for the store
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
-
-export { store };


### PR DESCRIPTION
This way we can handle our backend api more effectively, by registering them in a single place on the front end instead of calling axios again and again in different components (which leads to having to change something in multiple places should we ever alter our api)

Also updates rtk-toolkit to eliminate the lodash vulnerability