### PR TITLE
iOS middlware changes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -43,7 +43,7 @@
         "dotenv": "^16.4.7",
         "jest": "^29.7.0",
         "jsonwebtoken": "^9.0.2",
-        "mysql2": "^3.13.0",
+        "mysql2": "^3.12.0",
         "nodemon": "^3.1.9",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.6",
@@ -4739,6 +4739,7 @@
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -9033,7 +9034,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9033,7 +9033,8 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -115,14 +115,17 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     // Remove password from the response
     const { password: _, ...userData } = user;
 
-    // Set the cookie and respond
+    // Set the cookie and respond WITH JSON
     res
       .cookie("access_token", token, {
         httpOnly: true,
         // sameSite, secure, etc., as needed
       })
       .status(200)
-      .json(userData);
+      .json({
+        ...userData,   //login returning the token also, react front end should be fine
+      token
+    });
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
   }

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -18,8 +18,20 @@ export const verifyToken = (
 ): void => {
   try {
     // 1. Get token from cookies
-    const token = req.cookies.access_token;
+    //const token = req.cookies.access_token;
+    //try getting token through cookies
+    let token: string | undefined = req.cookies && req.cookies.access_token;
+
     if (!token) {
+      //res.status(401).json({ message: "Unauthorized" });
+      const authHeader = req.headers["authorization"];
+      if(authHeader && authHeader.startsWith("Bearer ")){
+        token = authHeader.split(" ")[1];
+      }
+    }
+    //if token isn't found in either cookies or header return appropriate error message
+    if(!token) {
+      console.error("No token found in cookies or authorization header");
       res.status(401).json({ message: "Unauthorized" });
       return;
     }


### PR DESCRIPTION
Some small changes to middleware files. Just adds the token in the response header so mobile clients can fetch, decode, and store the token for authentication between app sessions. React front end should be fine. 